### PR TITLE
Improve About Us page responsiveness

### DIFF
--- a/src/assets/styles/styles.css
+++ b/src/assets/styles/styles.css
@@ -286,5 +286,9 @@
   }
   .AboutUsHero{
     background-image: url("@/assets/images/AboutUs/Abouthero_mob.webp");
+    height: 400px;
+  }
+  .aboutUsReadyToEvolve{
+    height: 500px;
   }
 }

--- a/src/components/PageComponents/AboutUs/Desktop/AboutUsJoinNow.jsx
+++ b/src/components/PageComponents/AboutUs/Desktop/AboutUsJoinNow.jsx
@@ -4,7 +4,7 @@ function JoinUs() {
   return (
     <div className="w-full aboutUsReadyToEvolve pb-[76px] relative overflow-hidden">
       <div className="absolute inset-0 bg-black/20  z-0"></div>
-      <div className="w-full max-w-[1280px] mx-auto flex h-full min-h-[666px] items-end px-8">
+      <div className="w-full max-w-[1280px] mx-auto flex h-full min-h-[400px] md:min-h-[666px] items-end px-8">
         <div className="space-y-[24px] relative z-[9]">
           <h2 className="!text-[#fff] leading-[45px] uppercase">
             Ready to Evolve{" "}
@@ -16,7 +16,7 @@ function JoinUs() {
             supportive community so you can focus on your fitness, not the
             queue.
           </h4>
-          <div className="flex gap-6">
+          <div className="flex flex-col sm:flex-row gap-6">
             <button className="btnPrimary">JOIN NOW</button>
             <button className="btnSecondary">BOOK A FREE TOUR</button>
           </div>

--- a/src/components/PageComponents/AboutUs/Desktop/AboutUsMission.jsx
+++ b/src/components/PageComponents/AboutUs/Desktop/AboutUsMission.jsx
@@ -42,11 +42,11 @@ const cardsData = [
 
 function AboutUsMission() {
   return (
-    <div className="max-w-[1280px]  mx-auto w-full h-full">
-      <div className="flex flex-col md:flex-row gap-6 h-[660px] p-8 bg-[#FFF] mx-auto my-5">
+    <div className="max-w-[1280px] mx-auto w-full h-full">
+      <div className="flex flex-col md:flex-row gap-6 md:h-[660px] h-auto p-8 bg-[#FFF] mx-auto my-5">
 
         {/* OUR MISSION */}
-    <div className="flex flex-col items-start w-[351px] h-[598px] pt-[32px] pr-[54px] pb-[96px] pl-[55px] bg-[#F7F5F5] rounded-[10px]">
+    <div className="flex flex-col items-start w-full md:w-[351px] md:h-[598px] h-auto pt-[32px] pr-[54px] pb-[96px] pl-[55px] bg-[#F7F5F5] rounded-[10px]">
   
   <div className="w-[48px] mb-4">
     <img src={mission} alt="Mission Icon" className="w-full h-auto" />
@@ -65,9 +65,9 @@ function AboutUsMission() {
 
 
         {/* RIGHT TWO CARDS */}
-        <div className="space-y-3">
+        <div className="space-y-3 flex-1">
           {/* WHO WE ARE */}
-          <div className="flex flex-col items-start w-[865px] h-[293px] p-[32px_38px] gap-[10px] bg-[#F7F5F5] rounded-[10px]">
+          <div className="flex flex-col items-start w-full md:w-[865px] md:h-[293px] h-auto p-[32px_38px] gap-[10px] bg-[#F7F5F5] rounded-[10px]">
             <div className="text-green-600 text-3xl mb-2"><img src={whoarewe} /></div>
             <h2 className="text-[40px] font-[700] leading-[39px] uppercase text-[#1C1C1C] font-[kanit]">
               {cardsData[1].title}
@@ -76,9 +76,9 @@ function AboutUsMission() {
           </div>
 
           {/* ORIGIN STORY */}
-          <div className="flex flex-col items-start w-[865px] h-[293px] p-[32px_38px] gap-[10px] bg-[#1C1C1C] rounded-[10px] relative">
+          <div className="flex flex-col items-start w-full md:w-[865px] md:h-[293px] h-auto p-[32px_38px] gap-[10px] bg-[#1C1C1C] rounded-[10px] relative">
 
-            <div className="absolute top-[19px] left-[610px] w-[172px] h-[107px] flex-shrink-0">
+            <div className="absolute top-[19px] left-[610px] w-[172px] h-[107px] flex-shrink-0 hidden md:block">
               <img src={ourOriginStoryLogo} alt="Logo" className="w-full h-full object-contain" />
             </div>
             <div className="text-green-600 text-3xl mb-2">

--- a/src/components/PageComponents/AboutUs/Desktop/AboutUsOffer.jsx
+++ b/src/components/PageComponents/AboutUs/Desktop/AboutUsOffer.jsx
@@ -47,12 +47,12 @@ const MembershipPremiumAmenities = () => {
               {professionals.map((pro, idx) => (
                 <div
                   key={idx}
-                  className="flex-[0_0_32.5%] relative"
+                  className="flex-[0_0_80%] md:flex-[0_0_32.5%] relative"
                 >
                   <img
                     src={pro.image}
                     alt={pro.title}
-                    className="w-[400px] h-[273px] object-cover"
+                    className="w-full md:w-[400px] h-[273px] object-cover"
                   />
                   <h3 className="flex items-center mt-6 text-[#000] leading-[24px] font-[500]">
                     {pro.title}
@@ -63,7 +63,7 @@ const MembershipPremiumAmenities = () => {
             </div>
           </div>
 
-          <div className="absolute -top-1/6 -translate-y-1/2 left-[86%] z-10">
+          <div className="absolute -top-1/6 -translate-y-1/2 left-[86%] z-10 hidden md:block">
             <button
               onClick={scrollPrev}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"
@@ -71,7 +71,7 @@ const MembershipPremiumAmenities = () => {
               <ArrowLeft className="w-6 h-6" />
             </button>
           </div>
-          <div className="absolute -top-1/6 -translate-y-1/2 right-[6%] z-10">
+          <div className="absolute -top-1/6 -translate-y-1/2 right-[6%] z-10 hidden md:block">
             <button
               onClick={scrollNext}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"

--- a/src/components/PageComponents/AboutUs/Desktop/AboutUsPractitioners.jsx
+++ b/src/components/PageComponents/AboutUs/Desktop/AboutUsPractitioners.jsx
@@ -48,11 +48,11 @@ const AboutUsPractitioners = () => {
           <div className="overflow-hidden" ref={emblaRef}>
             <div className="flex gap-4 pl-4">
               {professionals.map((pro, idx) => (
-                <div key={idx} className="flex-[0_0_32.5%] relative">
+                <div key={idx} className="flex-[0_0_80%] md:flex-[0_0_32.5%] relative">
                   <img
                     src={pro.image}
                     alt={pro.title}
-                    className="w-[400px] h-[273px] object-cover"
+                    className="w-full md:w-[400px] h-[273px] object-cover"
                   />
                   <h3 className="flex items-center mt-6 text-[#000] leading-[24px] font-[500]">
                     {pro.title}
@@ -66,7 +66,7 @@ const AboutUsPractitioners = () => {
                  FIND A WELLNESS EXPERT
                 </button>
 
-          <div className="absolute -top-1/6 -translate-y-1/2 left-[86%] z-10">
+          <div className="absolute -top-1/6 -translate-y-1/2 left-[86%] z-10 hidden md:block">
             <button
               onClick={scrollPrev}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"
@@ -74,7 +74,7 @@ const AboutUsPractitioners = () => {
               <ArrowLeft className="w-6 h-6" />
             </button>
           </div>
-          <div className="absolute -top-1/6 -translate-y-1/2 right-[6%] z-10">
+          <div className="absolute -top-1/6 -translate-y-1/2 right-[6%] z-10 hidden md:block">
             <button
               onClick={scrollNext}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"

--- a/src/components/PageComponents/AboutUs/Desktop/AboutUsTrainers.jsx
+++ b/src/components/PageComponents/AboutUs/Desktop/AboutUsTrainers.jsx
@@ -50,12 +50,12 @@ const AboutUsTrainers = () => {
                             {professionals.map((pro, idx) => (
                                 <div
                                     key={idx}
-                                    className="flex-[0_0_32.5%] relative"
+                                    className="flex-[0_0_80%] md:flex-[0_0_32.5%] relative"
                                 >
                                     <img
                                         src={pro.image}
                                         alt={pro.title}
-                                        className="w-[400px] h-[273px] object-cover"
+                                        className="w-full md:w-[400px] h-[273px] object-cover"
                                     />
                                     <h3 className="flex items-center mt-6 text-[#000] leading-[24px] font-[500]">
                                         {pro.title}
@@ -66,7 +66,7 @@ const AboutUsTrainers = () => {
                         </div>
                     </div>
 
-                    <div className="absolute -top-1/6 -translate-y-1/2 left-[86%] z-10">
+                    <div className="absolute -top-1/6 -translate-y-1/2 left-[86%] z-10 hidden md:block">
                         <button
                             onClick={scrollPrev}
                             className="p-2 rounded-full border border-[#000000] text-[#000000]"
@@ -74,7 +74,7 @@ const AboutUsTrainers = () => {
                             <ArrowLeft className="w-6 h-6" />
                         </button>
                     </div>
-                    <div className="absolute -top-1/6 -translate-y-1/2 right-[6%] z-10">
+                    <div className="absolute -top-1/6 -translate-y-1/2 right-[6%] z-10 hidden md:block">
                         <button
                             onClick={scrollNext}
                             className="p-2 rounded-full border border-[#000000] text-[#000000]"


### PR DESCRIPTION
## Summary
- make the hero and join sections responsive on small screens
- update About Us mission section widths
- adjust carousels for better mobile display
- hide navigation arrows on mobile
- tweak background heights for mobile screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687f8bdc847c8320a602bd7da3f5d90f