### PR TITLE
Fix responsiveness on Locations page

### DIFF
--- a/src/components/PageComponents/Locations/Desktop/LoWhyChooseEvlove.jsx
+++ b/src/components/PageComponents/Locations/Desktop/LoWhyChooseEvlove.jsx
@@ -39,16 +39,16 @@ const LoWhyChooseEvolve = () => {
 
         <div className="relative">
           <div className="overflow-hidden" ref={emblaRef}>
-            <div className="flex gap-4 pl-4">
+            <div className="flex gap-4 pl-0 md:pl-4">
               {professionals.map((pro, idx) => (
                 <div
                   key={idx}
-                  className="flex-[0_0_50%] relative"
+                  className="flex-[0_0_100%] md:flex-[0_0_50%] relative"
                 >
                   <img
                     src={pro.image}
                     alt={pro.title}
-                    className="w-[600px] object-cover"
+                    className="w-full md:w-[600px] object-cover"
                   />
                   <h3 className="flex items-center mt-6 text-[#000] leading-[24px] font-[500]">
                     {pro.title}
@@ -61,7 +61,7 @@ const LoWhyChooseEvolve = () => {
             </div>
           </div>
 
-          <div className="absolute -top-1/6 -translate-y-1/2 left-[86%] z-10">
+          <div className="absolute top-1/2 -translate-y-1/2 left-4 md:left-[86%] z-10">
             <button
               onClick={scrollPrev}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"
@@ -69,7 +69,7 @@ const LoWhyChooseEvolve = () => {
               <ArrowLeft className="w-6 h-6" />
             </button>
           </div>
-          <div className="absolute -top-1/6 -translate-y-1/2 right-[6%] z-10">
+          <div className="absolute top-1/2 -translate-y-1/2 right-4 md:right-[6%] z-10">
             <button
               onClick={scrollNext}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"

--- a/src/components/PageComponents/Locations/Desktop/LocationPricing.jsx
+++ b/src/components/PageComponents/Locations/Desktop/LocationPricing.jsx
@@ -54,11 +54,11 @@ function LocationPricing() {
       </div>
 
       {/* Pricing Cards */}
-      <div className="flex gap-[24px]">
+      <div className="flex flex-col md:flex-row gap-4 md:gap-[24px]">
         {pricingContent.plans.map((plan, index) => (
           <div
             key={index}
-            className="flex flex-col w-[320px] p-[32px] shadow-lg border border-gray-200 rounded-[8px] bg-white"
+            className="flex flex-col w-full md:w-[320px] p-[32px] shadow-lg border border-gray-200 rounded-[8px] bg-white"
           >
             <h3 className=" ">{plan.title}</h3>
             <p className="!description">{plan.billing}</p>

--- a/src/components/PageComponents/Locations/Desktop/LocationsPartners.jsx
+++ b/src/components/PageComponents/Locations/Desktop/LocationsPartners.jsx
@@ -19,7 +19,7 @@ const LocationPartners = () => {
       <div className="w-full max-w-[1280px] px-8 mx-auto flex flex-col items-center justify-center gap-10">
         <h2 className="text-[#000000] uppercase">Our Equipment Partners</h2>
 
-        <div className="w-full flex items-center justify-between px-8">
+        <div className="w-full flex flex-wrap items-center justify-between px-8 gap-6 md:gap-0">
           {partnerLogos.map((logo, index) => (
             <img
               key={index}

--- a/src/components/PageComponents/Locations/Desktop/LocationsSpacious.jsx
+++ b/src/components/PageComponents/Locations/Desktop/LocationsSpacious.jsx
@@ -42,16 +42,16 @@ const MembershipPremiumAmenities = () => {
 
         <div className="relative">
           <div className="overflow-hidden" ref={emblaRef}>
-            <div className="flex gap-4 pl-4">
+            <div className="flex gap-4 pl-0 md:pl-4">
               {professionals.map((pro, idx) => (
                 <div
                   key={idx}
-                  className="flex-[0_0_32.5%] relative"
+                  className="flex-[0_0_100%] md:flex-[0_0_32.5%] relative"
                 >
                   <img
                     src={pro.image}
                     alt={pro.title}
-                    className="w-[400px] h-[273px] object-cover"
+                    className="w-full md:w-[400px] md:h-[273px] object-cover"
                   />
                   <h3 className="flex items-center mt-6 text-[#000] leading-[24px] font-[500]">
                     {pro.title}
@@ -62,7 +62,7 @@ const MembershipPremiumAmenities = () => {
             </div>
           </div>
 
-          <div className="absolute -top-1/6 -translate-y-1/2 left-[86%] z-10">
+          <div className="absolute top-1/2 -translate-y-1/2 left-4 md:left-[86%] z-10">
             <button
               onClick={scrollPrev}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"
@@ -70,7 +70,7 @@ const MembershipPremiumAmenities = () => {
               <ArrowLeft className="w-6 h-6" />
             </button>
           </div>
-          <div className="absolute -top-1/6 -translate-y-1/2 right-[6%] z-10">
+          <div className="absolute top-1/2 -translate-y-1/2 right-4 md:right-[6%] z-10">
             <button
               onClick={scrollNext}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"

--- a/src/components/PageComponents/Locations/Desktop/MeetTheTrainers.jsx
+++ b/src/components/PageComponents/Locations/Desktop/MeetTheTrainers.jsx
@@ -44,16 +44,16 @@ const MeetTheTrainers = () => {
 
         <div className="relative">
           <div className="overflow-hidden" ref={emblaRef}>
-            <div className="flex gap-6 pl-16">
+            <div className="flex gap-6 pl-0 md:pl-16">
               {professionals.map((pro, idx) => (
                 <div
                   key={idx}
-                  className="flex-[0_0_20.5%] relative"
+                  className="flex-[0_0_100%] md:flex-[0_0_20.5%] relative"
                 >
                   <img
                     src={pro.image}
                     alt={pro.title}
-                    className="w-[400px] h-[273px] object-cover"
+                    className="w-full md:w-[400px] md:h-[273px] object-cover"
                   />
                    <div className="w-[253px] h-[95px] bg-[#F6F6F6] border-[10px] mt-2 justify-center rounded-2xl border-transparent">
                    <div className="w-full h-[95px] bg-[#F6F6F6]  rounded-[10px] flex  justify-between">
@@ -75,7 +75,7 @@ const MeetTheTrainers = () => {
             </div>
           </div>
 
-          <div className="absolute top-[30%] left-[%] translate-y-1/2 ">
+          <div className="absolute top-1/2 -translate-y-1/2 left-4 md:left-0 ">
             <button
               onClick={scrollPrev}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"
@@ -83,7 +83,7 @@ const MeetTheTrainers = () => {
               <ArrowLeft className="w-6 h-6" />
             </button>
           </div>
-          <div className="absolute  top-[30%] translate-y-1/2 -right-[0.1%] z-10">
+          <div className="absolute top-1/2 -translate-y-1/2 right-4 md:right-0 z-10">
             <button
               onClick={scrollNext}
               className="p-2 rounded-full border border-[#000000] text-[#000000]"

--- a/src/components/PageComponents/Locations/Desktop/Services.jsx
+++ b/src/components/PageComponents/Locations/Desktop/Services.jsx
@@ -10,6 +10,13 @@ import {
   Brain,
   Hand,
 } from "lucide-react";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from "@/components/ui/carousel";
 
 import estheticianBg from "/src/assets/images/home/wellness-services/esthetician.webp";
 import chiropracticBg from "/src/assets/images/home/wellness-services/chiropractic_care.webp";
@@ -52,9 +59,10 @@ const Services = () => {
   }, []);
 
   return (
-    <div className="">
+    <div className="w-full md:py-12 max-md:pb-12 max-md:pt-0">
+      {/* Desktop View */}
       <div
-        className="relative flex flex-row items-center justify-center w-full  aspect-[16/9] bg-cover bg-center transition-all will-change-transform will-change-opacity"
+        className="relative flex flex-row items-center justify-center w-full aspect-[16/9] bg-cover bg-center transition-all will-change-transform will-change-opacity max-md:hidden"
         style={{ backgroundImage: `url(${services[activeIndex].bgImage})` }}
       >
 
@@ -105,6 +113,54 @@ const Services = () => {
               );
             })}
           </div>
+        </div>
+      </div>
+
+      {/* Mobile View */}
+      <div
+        className="md:hidden relative w-full min-h-[552px] bg-cover bg-center flex flex-col px-4 py-8 justify-between items-center overflow-hidden"
+        style={{ backgroundImage: `url(${services[activeIndex].bgImage})` }}
+      >
+        <div className="absolute inset-0 bg-black/40 z-0" />
+        <div className="relative z-10 flex flex-col items-center w-full gap-6">
+          <h2 className="uppercase text-[#ffffff] font-bold text-center">
+            WELLNESS SERVICES FOR EVERYONE.
+          </h2>
+          <p className="description leading-[20px] text-[#ffffff] text-center">
+            Fitness goes beyond the gym. Our in-house wellness team helps you recover, manage pain, and improve movement.
+          </p>
+          <div className="flex justify-start">
+            <button className="btnPrimary">BOOK A FREE TOUR</button>
+          </div>
+        </div>
+        <div className="relative w-full mt-6">
+          <Carousel opts={{ align: 'start' }} className="w-full">
+            <CarouselContent className="pl-5 gap-2">
+              {services.map((service, index) => {
+                const isActive = index === activeIndex;
+                return (
+                  <CarouselItem
+                    key={index}
+                    className={`flex-shrink-0 w-full max-w-[173px] h-[102px] flex flex-col items-center justify-center text-[#fff] rounded-[10px] cursor-pointer transition-all duration-300 ${
+                      isActive
+                        ? 'bg-white/20 border-white ring-2 ring-white border'
+                        : 'bg-[#00000066] border-transparent border'
+                    }`}
+                    onClick={() => setActiveIndex(index)}
+                  >
+                    <div className={`mb-1 text-[20px] ${isActive ? 'text-[#4AB04A]' : ''}`}>{service.icon}</div>
+                    <div className="text-[14px] font-kanit font-[400] leading-[20px] uppercase text-[#fff] text-center">
+                      {typeof service.label === 'string' ? service.label : (
+                        <span className="whitespace-pre-line">{service.label}</span>
+                      )}
+                    </div>
+                  </CarouselItem>
+                );
+              })}
+            </CarouselContent>
+            <CarouselPrevious className="left-0 top-1/2 -translate-y-1/2 bg-white/80 border border-gray-300" />
+            <CarouselNext className="right-0 top-1/2 -translate-y-1/2 bg-white/80 border border-gray-300" />
+          </Carousel>
         </div>
       </div>
     </div>

--- a/src/components/PageComponents/Locations/Desktop/SetonLocation.jsx
+++ b/src/components/PageComponents/Locations/Desktop/SetonLocation.jsx
@@ -12,18 +12,18 @@ function SetonLocation() {
     ABOUT OUR SETON LOCATION
   </h1>
 
-  <div className="flex  md:flex-row pl-5 gap-4">
+  <div className="flex flex-col md:flex-row pl-5 gap-4">
     {/* Left: Image */}
     <div className=" ">
       <img
         src={building}
         alt="Evolve Strength Seton"
-        className="w-[500px] h-[381px]object-cover rounded-md"
+        className="w-full md:w-[500px] h-auto md:h-[381px]object-cover rounded-md"
       />
     </div>
 
     {/* Right: Map + Info */}
-    <div className="w-[695px] h-[290px] flex flex-col ">
+    <div className="w-full md:w-[695px] h-auto md:h-[290px] flex flex-col ">
       {/* Map Image */}
       <img
         src={Map}
@@ -48,7 +48,7 @@ function SetonLocation() {
 
   {/* Optional: Facility Timing Toggle */}
   <div className="pl-5  ">
-    <button className="w-[1210px]  flex items-center justify-between px-4 py-3 bg-[#F9F9F9] !font-[600] text-black  border border-gray-200 rounded">
+    <button className="w-full md:w-[1210px]  flex items-center justify-between px-4 py-3 bg-[#F9F9F9] !font-[600] text-black  border border-gray-200 rounded">
       FACILITY TIMINGS
       <img src={icon} alt="" />
     </button>

--- a/src/index.css
+++ b/src/index.css
@@ -351,6 +351,6 @@ h5 {
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }

--- a/src/pages/Locations.jsx
+++ b/src/pages/Locations.jsx
@@ -18,7 +18,7 @@ import LoPersonalizedAssesment from '@/components/PageComponents/Locations/Deskt
 function Locations() {
   return (
          <div>
-      <div className="max-md:hidden">
+      <div className="overflow-x-hidden">
         <LocationHero />
         <LocationPartners/>
         <LoWhyChooseEvolve/>
@@ -36,7 +36,6 @@ function Locations() {
 
 
       </div>
-      <div className="md:hidden">Home Mobile</div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add overflow-x-hidden to body
- show Locations page content on all screens and remove mobile placeholder
- wrap equipment partner logos and tweak slider widths
- make carousels responsive for Why Choose, Spacious Facilities, and Meet the Trainers
- adapt pricing cards and Seton location layout for small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687f9a698f208320ac3e17a827b40e53