### PR TITLE
fix: Vancouver Post modal renders above navbar on all screen sizes

### DIFF
--- a/src/components/PageComponents/Franchise/Desktop/EvolveFloorPlan.jsx
+++ b/src/components/PageComponents/Franchise/Desktop/EvolveFloorPlan.jsx
@@ -92,7 +92,7 @@ const EvolveFloorPlan = ({
       </div>
       {videoSrc && modalOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+          className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/80"
           onClick={() => setModalOpen(false)}
         >
           <div
@@ -102,10 +102,10 @@ const EvolveFloorPlan = ({
             <button
               type="button"
               onClick={() => setModalOpen(false)}
-              className="absolute -top-10 right-0 text-white hover:text-gray-300 transition-colors"
+              className="absolute top-2 right-2 z-10 text-white hover:text-gray-300 transition-colors bg-black/50 rounded-full p-1"
               aria-label="Close video"
             >
-              <X className="h-8 w-8" />
+              <X className="h-6 w-6" />
             </button>
             <video
               src={videoSrc}


### PR DESCRIPTION
## Summary
- Hotfix for the video modal on the Vancouver Post location page
- Modal was rendering **behind the navbar** on lower-resolution / laptop screens
- X close button was positioned above the video frame and hidden behind the navbar on smaller screens

## Root Cause
Modal overlay used `z-50` but the navbar uses `z-[9999]` — the navbar always won.
X button was at `-top-10` (outside the video container), getting clipped by the navbar.

## Changes
- `src/components/PageComponents/Franchise/Desktop/EvolveFloorPlan.jsx`
  - Modal overlay: `z-50` → `z-[10000]` (above navbar's `z-[9999]`)
  - X button: moved from outside the frame (`-top-10 right-0`) to inside the top-right corner (`top-2 right-2`) with a semi-transparent background for visibility

## Test plan
- [ ] Visit `/locations/vancouver-post` on a laptop/lower-res screen
- [ ] Click the floor plan image — modal fully covers the navbar
- [ ] X button visible inside top-right corner of the video on all screen sizes
- [ ] ESC / clicking overlay still closes the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)