### PR TITLE
Update presale Edmonton South Common hero copy

### DIFF
--- a/src/components/PageComponents/PresaleEdmontonSouthCommon/PresaleEdmontonSouthCommonHero.jsx
+++ b/src/components/PageComponents/PresaleEdmontonSouthCommon/PresaleEdmontonSouthCommonHero.jsx
@@ -24,13 +24,13 @@ function PresaleEdmontonSouthCommonHero() {
         <div className="max-w-[1280px] md:px-8 px-4 md:pb-0 max-md:pb-[24px] mx-auto w-full h-full relative z-2">
           <div className="relative z-2 flex flex-col items-start justify-center md:pt-20 pt-0 h-full">
             <div className="text-[#FFFFFF] text-[12px] md:text-[16px] font-[600] backdrop-blur-[15px] uppercase leading-[24px] mb-4 md:mb-6 bg-[#20202066] md:!font-[70px] !font-[Kanit] border border-[#ADADAD] px-4 py-2 rounded-full">
-              Opening doors May 25th
+              The Countdown Is On. Opening May 25
             </div>
             <h1 className="text-[#FFFFFF] !font-[Kanit] uppercase max-w-[707px] leading-[40px] md:leading-[66px] max-md:!text-[36px] mb-4 md:mb-6 font-[600]">
-              Lock Your Founder Rate for Life
+              Lock Your Founder Rate Before Doors Open
             </h1>{" "}
             <h3 className="text-[#FFFFFF] !text-[16px] !font-[400] !leading-[20px] !md:leading-[24px] mb-8 max-w-[350px] md:max-w-[606px] !font-[Kanit]">
-              Early access. Lifetime pricing. Pay nothing until we open on May 25th.
+              Founder spots are filling fast. Lock rate for life. Early access, no payment until May 25th.
             </h3>
             <div className="flex gap-2 flex-col items-start">
               <Link to="/founder-offer-payment">
@@ -56,7 +56,7 @@ function PresaleEdmontonSouthCommonHero() {
                 </button>
               </Link>
               <p className="text-[#FFFFFF] !text-[16px] !font-[400] !font-[Kanit] leading-[24px] md:leading-[24px]  max-w-[250px] md:max-w-[190px]">
-              Spots filling up quickly
+              Limited spots remaining.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Badge: "The Countdown Is On. Opening May 25"
- H1: "Lock Your Founder Rate Before Doors Open"
- Subheading: "Founder spots are filling fast. Lock rate for life. Early access, no payment until May 25th."
- Below CTA: "Limited spots remaining."

## Test plan
- [ ] Desktop — check hero section at `/presale-edmonton-south-common`
- [ ] Mobile — verify all copy fits and wraps correctly

